### PR TITLE
bugfix

### DIFF
--- a/tierpsytools.egg-info/PKG-INFO
+++ b/tierpsytools.egg-info/PKG-INFO
@@ -15,13 +15,13 @@ Description: # tierpsytools
         To install tierpsytools clone the repository from github:
         
         ```bash
-        git clone https://github.com/em812/tierpsytools_python.git
+        git clone https://github.com/Tierpsy/tierpsy-tools-python.git
         ```
         
-        Go in the tierpsytools_python directory:
+        Go in the tierpsy-tools-python directory:
         
         ```bash
-        cd tierpsytools_python
+        cd tierpsy-tools-python
         ```
         
         and install the package with:

--- a/tierpsytools/extract_data/extract_tables_from_hdf5.py
+++ b/tierpsytools/extract_data/extract_tables_from_hdf5.py
@@ -45,7 +45,7 @@ def copy_table(table_names, src_fname, dst_fname):
     if not dst_fname.parent.exists():
         dst_fname.parent.mkdir(parents=True, exist_ok=True)
     with h5py.File(src_fname, 'r') as fids:
-        with h5py.File(dst_fname, 'r+') as fidd:
+        with h5py.File(dst_fname, 'a') as fidd:
             for table_name in table_names:
                 fids.copy(table_name, fidd['/'])
 


### PR DESCRIPTION
In `copy_table()`, from `tierpsytools/extract_data/extract_tables_from_hdf5`, I was opening the destination file in "r+" mode while it should have been in "a" mode. This gave an error if the destination file did not exist.