### PR TITLE
match_wells_annotations.py: bugfix 

### DIFF
--- a/tierpsytools/hydra/match_wells_annotations.py
+++ b/tierpsytools/hydra/match_wells_annotations.py
@@ -47,7 +47,7 @@ def import_wells_annotations(annotations_file,
                                             'well_label',
                                             'well_name']],
                                     on='file_id',
-                                    right_index=True,
+                                    # right_index=True,
                                     validate='one_to_many')
     annotations_df['imgstore_prestim'] = annotations_df.filename.apply(
                                         lambda x: x.split('/')[0])
@@ -95,8 +95,8 @@ def match_rawvids_annotations(rawvid_dir,
 
     Parameters
     ----------
-    target_dir : directory of RawVideos (pathlib)
-        DESCRIPTION.
+    rawvid_dir : pathlib Path
+        Directory where to look for raw videos.
     annotations_df : output from import_wells_annotations
         DESCRIPTION.
     bluelight_names : TYPE, optional


### PR DESCRIPTION
ambiguous merging not working on newer pandas?
was not a problem on pandas 1.1.3, gave error on 1.2.5