### PR TITLE
masked_videos_checks.py: bugfix

### DIFF
--- a/tierpsytools/hydra/masked_videos_checks.py
+++ b/tierpsytools/hydra/masked_videos_checks.py
@@ -69,7 +69,7 @@ def get_prestim_videos(day_root_dir):
                              )
     prestim_videos.drop(columns='imgstore_camera',
                         inplace=True)
-    prestim.sort_values(by=['run_number', 'rig', 'channel'], inplace=True)
+    prestim_videos.sort_values(by=['run_number', 'rig', 'channel'], inplace=True)
 
     return prestim_videos
 # %%


### PR DESCRIPTION
the dataframe `prestim` was being sorted at the end of `get_prestim_videos`, rather than the correct `prestim_videos`