### PR TITLE
bugfix in fingerprints.py

### DIFF
--- a/tierpsytools/analysis/fingerprints.py
+++ b/tierpsytools/analysis/fingerprints.py
@@ -163,7 +163,7 @@ class tierpsy_fingerprints():
 
         """
         if not hasattr(self, 'test_results'):
-            self._run_univariate_tests(X, y, control='N2', n_jobs=-1)
+            self._run_univariate_tests(X, y, control=control, n_jobs=-1)
         self._create_profile()
         return
 


### PR DESCRIPTION
the `fit` method of the class `tierpsy_fingerprints` was ignoring the `control` argument and setting it to 'N2' when calling the private method `_run_univariate_tests()`