### PR TITLE
get_timeseries.py: bugfix

### DIFF
--- a/tierpsytools/read_data/get_timeseries.py
+++ b/tierpsytools/read_data/get_timeseries.py
@@ -57,9 +57,10 @@ def read_timeseries(filename, names=None, only_wells=None):
                      If None, the timeseries will not be filtered by well
                      (good for legacy data)
     """
-    assert isinstance(only_wells, list), 'only_wells must be a list'
-    assert all(isinstance(well, str) for well in only_wells), \
-        'only_wells must be a list'
+    if only_wells is not None:
+      assert isinstance(only_wells, list), 'only_wells must be a list, or None'
+      assert all(isinstance(well, str) for well in only_wells), \
+          'only_wells must be a list of strings'
     with pd.HDFStore(filename, 'r') as f:
         if only_wells is None:
             series = f['timeseries_data']


### PR DESCRIPTION
default argument `only_wells=None` was creating issues with input type check