### PR TITLE
Trajectory plots without maskedfiles

### DIFF
--- a/tierpsytools/analysis/count_worms.py
+++ b/tierpsytools/analysis/count_worms.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Oct 14 19:50:33 2021
+
+@author: lferiani
+"""
+
+import pandas as pd
+
+from tierpsytools.read_data.get_timeseries import read_timeseries
+
+
+def n_worms_per_frame(timestamp, max_t: int = None) -> pd.Series:
+    """
+    n_worms_per_frame Take an array or pd.Series with timestamps, as you'd get
+    from Tierpsy, and determine how many worms were detected over time.
+    The rationale behind the maths is that if a timestamp appears twice, two
+    worms were detected at the same time, so n=2 for that frame.
+    This function also makes sure that if no worms were detected in frame i,
+    this is reflected in the results.
+
+    Parameters
+    ----------
+    timestamp : iterable
+        frame numbers from the timeseries or trajectories in tierpsy's results
+    max_t : int, optional
+        number of frames in a video, by default None
+        If empty, the maximum value of timestamp will be used.
+        It is important to use `max_t` to account for the edge case in which no
+        worms are detected at the end of the video
+
+    Returns
+    -------
+    pd.Series
+        number of worms tracked (values) versus time (series index).
+        The output of this function can then be passed on to
+        `fraction_of_time_with_n_worms`
+    """
+
+    # use pandas series. could use numpy but only > 1.18
+    if not isinstance(timestamp, pd.Series):
+        import pdb
+        pdb.set_trace()
+        timestamp = pd.Series(timestamp)
+
+    # if timestamp is all nan, then that's likely a well that was never recorded
+    if timestamp.isna().all():
+        # that won't affect the function actually,
+        # just that I cannot do the next check
+        pass
+    else:
+        # check all integers - easier than testing all type of int dtypes
+        # assert timestamp.astype(str).str.isdigit().all(), (
+        #     "Need to use integer timestamps")
+        if any(timestamp % 1 != 0):
+            err_msg = 'Non integer timestamp found:\n'
+            err_msg += f'{timestamp[timestamp % 1 != 0]}'
+            err_msg += '\nANeed to use integer timestamps'
+            raise ValueError(err_msg)
+
+
+    if max_t is None:
+        max_t = timestamp.max()
+    if max_t != max_t:
+        # max_t is nan
+        max_t = 0
+
+    # count how many repeated values for each entry in timestamp
+    n_worms_vs_time = timestamp.value_counts().sort_index()
+
+    # the above will not count zeros for missing values
+    n_worms_vs_time = n_worms_vs_time.reindex(
+        pd.Index(range(max_t + 1), name='timestamp'),
+        fill_value=0
+        )
+    n_worms_vs_time.name = 'n_worms'
+
+    return n_worms_vs_time
+
+
+def _fraction_of_time_with_n_worms(
+        n_worms_vs_time: pd.Series, max_n: int = None) -> pd.Series:
+    """
+    fraction_of_time_with_n_worms Given a pd.Series with
+        number of worms tracked (values) versus time (series index),
+        calculate the fraction of time that 0, 1, .., n worms were detected
+
+
+    Parameters
+    ----------
+    n_worms_vs_time : pd.Series
+        number of worms tracked (values) versus time (series index)
+        output of `n_worms_per_frame`
+    max_n : int, optional
+        maximum number of worms expected in a frame, by default None
+        If empty, the maximum number of worms detected will be used.
+        It is important to set max_n to account for the case in which tierpsy
+        never detects all the worms in a well at the same time.
+
+    Returns
+    -------
+    pd.Series
+        what fraction of time/a video (values) tierpsy tracked n worms (index)
+    """
+
+    if max_n is None:
+        max_n = n_worms_vs_time.max()
+
+    # what proportion of a video did we see 0, 1, 2 worms?
+    # sort=None sorts by index, which is the number of worms
+    # normalize=True divides by the total number of values
+    time_fraction_n_worms = n_worms_vs_time.value_counts(
+        sort=False, normalize=True)
+
+    # there might have been gaps in the numer of worms before
+    # (e.g. only ever 1 or 3 worms seen at same time)
+    # which is ok for the normalisation but bad for plotting later
+    time_fraction_n_worms = time_fraction_n_worms.reindex(
+        pd.Index(range(max_n + 1), name='n_worms'),
+        fill_value=0
+        )
+    time_fraction_n_worms.name = 'time_fraction'
+
+    return time_fraction_n_worms
+
+
+def get_frequency_of_detecting_n_worms_in_one_well(
+        timestamp, max_t: int = None, max_n: int = None) -> pd.Series:
+    """
+    get_frequency_of_detecting_n_worms_in_one_well Take an array or pd.Series
+        with timestamps, as you'd get from Tierpsy, and calculate what fraction
+        of the time 0, 1, 2, ... max_n worms were detected at the same time.
+
+    This is mostly a wrapper for the functions `n_worms_per_frame`
+
+    Parameters
+    ----------
+    timestamp : iterable
+        frame numbers from the timeseries or trajectories in tierpsy's results
+    max_t : int, optional
+        number of frames in a video, by default None
+        If empty, the maximum value of timestamp will be used.
+        It is important to use `max_t` to account for the edge case in which no
+        worms are detected at the end of the video
+    max_n : int, optional
+        maximum number of worms expected in a frame, by default None
+        If empty, the maximum number of worms detected will be used.
+        It is important to set max_n to account for the case in which tierpsy
+        never detects all the worms in a well at the same time.
+
+    Returns
+    -------
+    pd.Series
+        what fraction of a video (values) tierpsy tracked n worms (index)
+
+    """
+    nw = n_worms_per_frame(timestamp, max_t=max_t)
+    ft = _fraction_of_time_with_n_worms(nw, max_n=max_n)
+    return ft
+
+
+def get_frequency_of_detecting_n_worms(
+        onevideo_meta: pd.DataFrame, max_t: int = None, max_n: int = None
+        ) -> pd.Series:
+    """
+    get_frequency_of_detecting_n_worms Given a pandas dataframe containing
+        the metadata relative to a single video, read the timeseries_data
+        from the files in the `feats_fname` column, and on a well-by-well basis
+        calculate what fraction of time tierpsy detected 0, 1, ..., `max_n`
+        worms at the same time.
+        Will not work with featuresN files generated with Tierpsy < 1.5.2
+
+    Parameters
+    ----------
+    onevideo_meta : pd.DataFrame
+        metadata pertaining to one video only. Must contain a column called
+        `feats_fname` with the full path to the features file
+    max_t : int, optional
+        number of frames in a video, by default None
+        If empty, the maximum value of timestamp will be used.
+        It is important to use `max_t` to account for the edge case in which no
+        worms are detected at the end of the video
+    max_n : int, optional
+        maximum number of worms expected in a frame, by default None
+        If empty, the maximum number of worms detected will be used.
+        It is important to set max_n to account for the case in which tierpsy
+        never detects all the worms in a well at the same time.
+
+    Returns
+    -------
+    pd.Series
+        for each well in the video's timeseries,
+        what fraction of the video (values) tierpsy tracked n worms (index)
+    """
+
+    # check the full path to the timeseries exists
+    assert 'feats_fname' in onevideo_meta, (
+        '`onevideo_meta` must contain a column '
+        'with the full path to the features file'
+        )
+    # check it's a chunk of metadata that only contains data from the one video
+    assert onevideo_meta['feats_fname'].nunique() == 1, (
+        '`onevideo_meta` cannot contain metadata from multiple videos')
+    fname = onevideo_meta['feats_fname'].values[0]
+
+    # wells to read
+    if 'well_name' in onevideo_meta:
+        only_wells = onevideo_meta['well_name'].to_list()
+    else:
+        only_wells = None
+
+    # load timeseries
+    ts = read_timeseries(
+        fname, names=['well_name', 'timestamp'], only_wells=only_wells)
+
+    # if no worms were ever detected in a well, they'll be missing from here.
+    # so add them back in, so that the other functions can correctly return
+    # that 0 worms were seen throughout the whole video
+    ts = pd.merge(
+        ts, onevideo_meta[['well_name']], on='well_name', how='right')
+
+    # count fraction of time per each well
+    ft = ts.groupby('well_name')['timestamp'].apply(
+        get_frequency_of_detecting_n_worms_in_one_well,
+        max_t=max_t,
+        max_n=max_n
+        ).rename('time_fraction')
+
+    expected_n_rows = onevideo_meta.shape[0] * (max_n+1)
+    actual_n_rows = ft.shape[0]
+    assert expected_n_rows == actual_n_rows, (
+        f'Output has {actual_n_rows}, was expecting {expected_n_rows}.')
+
+    return ft
+
+
+def _test_toy():
+    # toy data
+    max_t = 7
+    max_n = 4
+    x = [1, 1, 1, 3, 3, 4, 4, 6, 6, 6]
+    y = n_worms_per_frame(x, max_t=max_t)
+    z = _fraction_of_time_with_n_worms(y, max_n=max_n)
+
+    zz = get_frequency_of_detecting_n_worms_in_one_well(
+        x, max_t=max_t, max_n=max_n)
+
+    expected = pd.Series([0.5, 0, 0.25, 0.25, 0], name='time_fraction')
+    expected.index.name = 'n_worms'
+    assert z.equals(expected)
+    assert z.equals(zz)
+
+
+if __name__ == '__main__':
+    _test_toy()

--- a/tierpsytools/plot/plot_plate_trajectories_with_raw_video_background.py
+++ b/tierpsytools/plot/plot_plate_trajectories_with_raw_video_background.py
@@ -4,8 +4,8 @@
 Plot 96-well Plate Trajectories
 
 A script to plot trajectories for worms tracked in all the wells of the 96-well
-plate to which that video belongs. Just provide a featuresN filepath from 
-Tierpsy filenames summaries and a plot will be produced of tracked worm 
+plate to which that video belongs. Just provide a featuresN filepath from
+Tierpsy filenames summaries and a plot will be produced of tracked worm
 trajectories throughout the video, for the entire 96-well plate (imaged under
 6 cameras simultaneously).
 
@@ -14,7 +14,7 @@ trajectories throughout the video, for the entire 96-well plate (imaged under
 
 """
 
-#%% Imports 
+#%% Imports
 
 import sys
 import h5py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 from tierpsy.analysis.split_fov.FOVMultiWellsSplitter import FOVMultiWellsSplitter
 from tierpsy.analysis.split_fov.helper import CAM2CH_df, serial2channel, parse_camera_serial
-
+from tierpsy.analysis.compress.selectVideoReader import selectVideoReader
 
 #%% Channel-to-plate mapping dictionary (global)
 
@@ -37,15 +37,15 @@ CH2PLATE_dict = {'Ch1':((0,0),True),
                  'Ch4':((1,1),False),
                  'Ch5':((0,2),True),
                  'Ch6':((1,2),False)}
-  
+
 
 #%% Functions
-        
+
 def get_trajectory_data(featuresfilepath):
-    """ Read Tierpsy-generated featuresN file trajectories data and return 
+    """ Read Tierpsy-generated featuresN file trajectories data and return
         the following info as a dataframe:
         ['x', 'y', 'frame_number', 'worm_id'] """
-        
+
     # Read HDF5 file + extract info
     with h5py.File(featuresfilepath, 'r') as f:
         df = pd.DataFrame({'x': f['trajectories_data']['coord_x'],\
@@ -55,20 +55,20 @@ def get_trajectory_data(featuresfilepath):
     return(df)
 
 
-def plot_trajectory(featurefilepath, 
-                   ax=None, 
-                   downsample=10, 
-                   legend=True, 
-                   rotate=False, 
-                   img_shape=None, 
+def plot_trajectory(featurefilepath,
+                   ax=None,
+                   downsample=10,
+                   legend=True,
+                   rotate=False,
+                   img_shape=None,
                    **kwargs):
     """ Overlay feature file trajectory data onto existing figure """
-        
+
     df = get_trajectory_data(featurefilepath)
-    
+
     if not ax:
         fig, ax = plt.subplots(**kwargs)
- 
+
     # Rotate trajectories when plotting a rotated image
     if rotate:
         if not img_shape:
@@ -77,7 +77,7 @@ def plot_trajectory(featurefilepath,
             height, width = img_shape[0], img_shape[1]
             df['x'] = width - df['x']
             df['y'] = height - df['y']
-        
+
     # Downsample frames for plotting
     if downsample <= 1 or downsample == None: # input error handling
         ax.scatter(x=df['x'], y=df['y'], s=10, c=df['frame_number'],\
@@ -88,56 +88,66 @@ def plot_trajectory(featurefilepath,
     #ax.tick_params(labelsize=5)
     ax.axes.get_xaxis().set_visible(False)
     ax.axes.get_yaxis().set_visible(False)
-    
+
     if legend:
         _legend = plt.colorbar(pad=0.01)
         _legend.ax.get_yaxis().labelpad = 10 # legend spacing
         _legend.ax.set_ylabel('Frame Number', rotation=270, size=7) # legend label
         _legend.ax.tick_params(labelsize=5)
-    
+
     ax.autoscale(enable=True, axis='x', tight=True) # re-scaling axes
     ax.autoscale(enable=True, axis='y', tight=True)
- 
+
 
 def get_video_set(featurefilepath):
     """ Get the set of filenames of the featuresN results files that belong to
         the same 96-well plate that was imaged under that rig """
-        
-    dirpath = Path(featurefilepath).parent
-    maskedfilepath = Path(str(dirpath).replace("Results/","MaskedVideos/"))
-    
+
     # get camera serial from filename
     camera_serial = parse_camera_serial(featurefilepath)
-    
+
     # get list of camera serials for that hydra rig
     hydra_rig = CAM2CH_df.loc[CAM2CH_df['camera_serial']==camera_serial,'rig']
     rig_df = CAM2CH_df[CAM2CH_df['rig']==hydra_rig.values[0]]
     camera_serial_list = list(rig_df['camera_serial'])
-   
-    # extract filename stem 
-    file_stem = str(maskedfilepath).split('.' + camera_serial)[0]
-    
+
+    # extract filename stem
+    file_stem = str(featurefilepath).split('.' + camera_serial)[0]
+
     file_dict = {}
     for camera_serial in camera_serial_list:
         channel = serial2channel(camera_serial)
-        _loc, rotate = CH2PLATE_dict[channel]
-        
-        # get path to masked video file
-        maskedfilepath = Path(file_stem + '.' + camera_serial) / "metadata.hdf5"
-        featurefilepath = Path(str(maskedfilepath.parent).replace("MaskedVideos/",\
-                               "Results/")) / 'metadata_featuresN.hdf5'
-        
-        file_dict[channel] = (maskedfilepath, featurefilepath)
-        
+
+        ch_featfilepath = Path(file_stem + '.' + camera_serial)
+        ch_featfilepath /= 'metadata_featuresN.hdf5'
+
+        file_dict[channel] = ch_featfilepath
+
     return file_dict
 
-    
+
+def feat2raw(featfilepath):
+    """Get imgstore name that corresponds to a results video"""
+    rawfilepath = Path(
+        str(featfilepath.parent).replace('Results', 'RawVideos')
+        ) / 'metadata.yaml'
+    assert rawfilepath.exists(), f'Cannot find imgstore for {featfilepath}'
+    return rawfilepath
+
+
+def get_frame_from_raw(rawvidname):
+    vid = selectVideoReader(str(rawvidname))
+    status, frame = vid.read_frame(0)
+    assert status == 1, f'Something went wrong while reading {rawvidname}'
+    return frame
+
+
 def plot_plate_trajectories(featurefilepath, saveDir=None, downsample=10):
-    """ Tile plots and merge into a single plot for the 
+    """ Tile plots and merge into a single plot for the
         entire 96-well plate, correcting for camera orientation. """
-        
+
     file_dict = get_video_set(featurefilepath)
-    
+
     # define multi-panel figure
     columns = 3
     rows = 2
@@ -151,9 +161,9 @@ def plot_plate_trajectories(featurefilepath, saveDir=None, downsample=10):
     width = (1-x_offset) / columns  # for all but top left image
     width_tl = width + x_offset   # for top left image
     height = 1/rows        # for all images
-    
-    for channel, (maskedfilepath, featurefilepath) in file_dict.items():
-        
+
+    for channel, ch_featfilepath in file_dict.items():
+
         _loc, rotate = CH2PLATE_dict[channel]
         _ri, _ci = _loc
 
@@ -163,35 +173,39 @@ def plot_plate_trajectories(featurefilepath, saveDir=None, downsample=10):
             bbox = [0, height, width_tl, height]
         else:
             # other images
-            bbox = [x_offset + width * _ci, height * (rows - (_ri + 1)), width, height]   
-        
+            bbox = [x_offset + width * _ci, height * (rows - (_ri + 1)), width, height]
+
         # get location of subplot for camera
         ax = axs[_loc]
-        
+
         # plot first frame of video + annotate wells
-        FOVsplitter = FOVMultiWellsSplitter(maskedfilepath)
-        FOVsplitter.plot_wells(is_rotate180=rotate, ax=ax, line_thickness=10)
-        
+        fovsplitter = FOVMultiWellsSplitter(ch_featfilepath)
+        # let's check if the fovsplitter managed to get a frame automatically
+        if fovsplitter.img is None:
+            fovsplitter.img = get_frame_from_raw(feat2raw(ch_featfilepath))
+
+        fovsplitter.plot_wells(is_rotate180=rotate, ax=ax, line_thickness=10)
+
         # plot worm trajectories
-        plot_trajectory(featurefilepath, 
-                       ax=ax, 
+        plot_trajectory(ch_featfilepath,
+                       ax=ax,
                        downsample=downsample,
-                       legend=False, 
-                       rotate=rotate, 
-                       img_shape=FOVsplitter.img_shape)
-        
+                       legend=False,
+                       rotate=rotate,
+                       img_shape=fovsplitter.img_shape)
+
         # set image position in figure
         ax.set_position(bbox)
-        
+
     plt.show()
     if saveDir:
-        saveName = maskedfilepath.parent.stem + '.png'
+        saveName = Path(featurefilepath).parent.stem + '.png'
         savePath = Path(saveDir) / saveName
         fig.savefig(savePath,
                     bbox_inches='tight',
                     dpi=300,
                     pad_inches=0,
-                    transparent=True)            
+                    transparent=True)
     return(fig)
 
 
@@ -201,34 +215,34 @@ def plot_plate_trajectories_from_filenames_summary(filenames_path, saveDir):
 
     filenames_df = pd.read_csv(filenames_path, comment='#')
     filenames_list = filenames_df[filenames_df['is_good']==True]['file_name']
-    
+
     filestem_list = []
-    featurefile_list = []  
+    featurefile_list = []
     for fname in filenames_list:
         # obtain file stem
         filestem = Path(fname).parent.parent / Path(fname).parent.stem
-        
-        # only record featuresN filepaths with a different file stem as we only 
+
+        # only record featuresN filepaths with a different file stem as we only
         # need 1 camera's video per plate to find the others
         if filestem not in filestem_list:
             filestem_list.append(filestem)
             featurefile_list.append(fname)
-    
+
     # overlay trajectories and combine plots for each plate that was imaged
     for featurefilepath in tqdm(featurefile_list):
         plot_plate_trajectories(featurefilepath, saveDir)
-        
-        
+
+
 #%% Main
-    
+
 if __name__ == "__main__":
     print("\nRunning: ", sys.argv[0])
-    
+
     example_featuresN = Path("/Volumes/behavgenom$/Saul/MicrobiomeScreen96WP/Results/20200222/microbiome_screen2_run7_p1_20200222_122858.22956805/metadata_featuresN.hdf5")
-    
+
     parser = argparse.ArgumentParser()
     # default to example file if none given
-    parser.add_argument("--input", help="input file path (featuresN)", 
+    parser.add_argument("--input", help="input file path (featuresN)",
                         default=example_featuresN)
     # default to input's grandparent if non given
     known_args = parser.parse_known_args()
@@ -240,7 +254,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     print("Input file:", args.input)
     print("Output directory:", args.output)
-    
+
     plot_plate_trajectories(args.input, saveDir=args.output, downsample=10)
 
-    
+


### PR DESCRIPTION
plotting trajectories on a raw video frame does not need the masked videos to exist.

The fovsplitter creator is called based on the results name. If the corresponding masked video file does exist, the fovsplitter will automatically load a frame from there (this is handled by the fovsplitter class). But if the masked video does not exist, the plotting function will try to read the first frame of the imgstore whose name is derived from the featuresN.hdf5 file